### PR TITLE
Add stickers feature

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,6 +37,7 @@ defmodule Reverie.Mixfile do
      {:gettext, "~> 0.11"},
      {:cors_plug, "~> 1.1"},
      {:ja_serializer, "~> 0.11.2"},
+     {:inquisitor, "~> 0.2"},
      {:comeonin, "~> 2.4"},
      {:guardian, "~> 0.14.0"},
      {:cowboy, "~> 1.0"}]

--- a/mix.lock
+++ b/mix.lock
@@ -10,6 +10,7 @@
   "gettext": {:hex, :gettext, "0.13.0", "daafbddc5cda12738bb93b01d84105fe75b916a302f1c50ab9fb066b95ec9db4", [:mix], []},
   "guardian": {:hex, :guardian, "0.14.0", "b33b39e6173c021f5f9390a74aa6330f6cec6e22d652b78abfef8da40622f8e7", [:mix], [{:jose, "~> 1.8", [hex: :jose, optional: false]}, {:phoenix, "~> 1.2.0", [hex: :phoenix, optional: true]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.3.0", [hex: :poison, optional: false]}, {:uuid, ">=1.1.1", [hex: :uuid, optional: false]}]},
   "inflex": {:hex, :inflex, "1.8.0", "7cfc752ae244b30b42ac9cf4c092771b485bc3424139aba4a933e54be8c63931", [:mix], []},
+  "inquisitor": {:hex, :inquisitor, "0.2.0", "8b1691c061e212f9386d8ec0c14e3d7ab98725b6f31ba58c4bd896f697eda617", [:mix], [{:ecto, "> 2.0.0", [hex: :ecto, optional: false]}]},
   "ja_serializer": {:hex, :ja_serializer, "0.11.2", "952b59b480e656e0bd991c5822dda4dfc6c507f1c55d6eaea363cd84e6002e2c", [:mix], [{:inflex, "~> 1.4", [hex: :inflex, optional: false]}, {:plug, "> 1.0.0", [hex: :plug, optional: false]}, {:poison, "~> 1.4 or ~> 2.0", [hex: :poison, optional: false]}, {:scrivener, "~> 1.2 or ~> 2.0", [hex: :scrivener, optional: true]}]},
   "jose": {:hex, :jose, "1.8.0", "1ee027c5c0ff3922e3bfe58f7891509e8f87f771ba609ee859e623cc60237574", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, optional: false]}]},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},

--- a/priv/repo/migrations/20170107150424_create_sticker.exs
+++ b/priv/repo/migrations/20170107150424_create_sticker.exs
@@ -1,0 +1,16 @@
+defmodule Reverie.Repo.Migrations.CreateSticker do
+  use Ecto.Migration
+
+  def change do
+    create table(:stickers) do
+      add :title, :string
+      add :sender_id, references(:users, on_delete: :nothing)
+      add :receiver_id, references(:users, on_delete: :nothing)
+
+      timestamps()
+    end
+    create index(:stickers, [:sender_id])
+    create index(:stickers, [:receiver_id])
+
+  end
+end

--- a/test/controllers/sticker_controller_test.exs
+++ b/test/controllers/sticker_controller_test.exs
@@ -83,9 +83,12 @@ defmodule Reverie.StickerControllerTest do
 
   test "does not create resource and renders errors when data is invalid", %{conn: conn, user: user} do
     other_user = Repo.insert! %Reverie.User{}
-
     conn = post conn, sticker_path(conn, :create), data: %{type: "stickers", attributes: @invalid_attrs, relationships: %{"data": %{"type": "users", "id": other_user.id}}}
+    assert json_response(conn, 422)["errors"] != %{}
+  end
 
+  test "does not create resource and renders errors when user sends themselves a sticker", %{conn: conn, user: user} do
+    conn = post conn, sticker_path(conn, :create), data: %{type: "stickers", attributes: @valid_attrs, relationships: %{"data": %{"type": "users", "id": user.id}}}
     assert json_response(conn, 422)["errors"] != %{}
   end
 

--- a/test/controllers/sticker_controller_test.exs
+++ b/test/controllers/sticker_controller_test.exs
@@ -56,12 +56,12 @@ defmodule Reverie.StickerControllerTest do
       "relationships" => %{
         "receiver" => %{
           "links" => %{
-            "related" => "http://localhost:4001/api/user/#{user.id}"
+            "related" => "http://localhost:4001/api/users/#{user.id}"
           }
         },
         "sender" => %{
           "links" => %{
-            "related" => "http://localhost:4001/api/user/#{other_user.id}"
+            "related" => "http://localhost:4001/api/users/#{other_user.id}"
           }
         }
       }

--- a/test/controllers/sticker_controller_test.exs
+++ b/test/controllers/sticker_controller_test.exs
@@ -76,19 +76,20 @@ defmodule Reverie.StickerControllerTest do
 
   test "creates and renders resource when data is valid, using id", %{conn: conn, user: user} do
     other_user = Repo.insert! %Reverie.User{}
-    conn = post conn, sticker_path(conn, :create), data: %{type: "stickers", attributes: @valid_attrs, relationships: %{"data": %{"type": "users", "id": other_user.id}}}
+    conn = post conn, sticker_path(conn, :create), data: %{type: "stickers", attributes: @valid_attrs, relationships: %{"receiver": %{"data": %{"type": "users", "id": other_user.id}}, "sender": %{"data": %{"type": "users", "id": user.id}}}}
+
     assert json_response(conn, 201)["data"]["id"]
     assert Repo.get_by(Sticker, @valid_attrs)
   end
 
   test "does not create resource and renders errors when data is invalid", %{conn: conn, user: user} do
     other_user = Repo.insert! %Reverie.User{}
-    conn = post conn, sticker_path(conn, :create), data: %{type: "stickers", attributes: @invalid_attrs, relationships: %{"data": %{"type": "users", "id": other_user.id}}}
+    conn = post conn, sticker_path(conn, :create), data: %{type: "stickers", attributes: @invalid_attrs, relationships: %{"receiver": %{"data": %{"type": "users", "id": other_user.id}}, "sender": %{"data": %{"type": "users", "id": user.id}}}}
     assert json_response(conn, 422)["errors"] != %{}
   end
 
   test "does not create resource and renders errors when user sends themselves a sticker", %{conn: conn, user: user} do
-    conn = post conn, sticker_path(conn, :create), data: %{type: "stickers", attributes: @valid_attrs, relationships: %{"data": %{"type": "users", "id": user.id}}}
+    conn = post conn, sticker_path(conn, :create), data: %{type: "stickers", attributes: @invalid_attrs, relationships: %{"receiver": %{"data": %{"type": "users", "id": user.id}}, "sender": %{}}}
     assert json_response(conn, 422)["errors"] != %{}
   end
 

--- a/test/controllers/sticker_controller_test.exs
+++ b/test/controllers/sticker_controller_test.exs
@@ -1,0 +1,99 @@
+defmodule Reverie.StickerControllerTest do
+  use Reverie.ConnCase
+
+  alias Reverie.Sticker
+  @valid_attrs %{title: "some content"}
+  @invalid_attrs %{}
+
+  defp create_test_stickers(user) do
+    other_user = Repo.insert! %Reverie.User{}
+
+    # Three stickers with the logged-in user as receiver, other as sender
+    Enum.each ["first", "second", "third"], fn title ->
+      Repo.insert! %Reverie.Sticker{receiver_id: user.id, sender_id: other_user.id, title: title}
+    end
+
+    # Two stickers with other as receiver, logged-in user as sender
+    Enum.each ["fourth", "fifth"], fn title ->
+      Repo.insert! %Reverie.Sticker{receiver_id: other_user.id, sender_id: user.id, title: title}
+    end
+  end
+
+  setup %{conn: conn} do
+    # Crerate a user (bypassing validation)
+    user = Repo.insert! %Reverie.User{}
+    # Encode JWT for the user
+    {:ok, jwt, _} = Guardian.encode_and_sign(user, :token)
+
+    conn = conn
+    |> put_req_header("content-type", "application/vnd.api+json")
+    |> put_req_header("authorization", "Bearer #{jwt}")
+
+    {:ok, %{conn: conn, user: user}}
+  end
+
+  test "lists owned entries on index (receiver_id == user id)", %{conn: conn, user: user} do
+    # Build test stickers
+    create_test_stickers user
+
+    # List of stickers owned by user
+    conn = get conn, sticker_path(conn, :index, user_id: user.id)
+    assert Enum.count(json_response(conn, 200)["data"]) == 3
+  end
+
+  test "shows chosen resource", %{conn: conn, user: user} do
+    other_user = Repo.insert! %Reverie.User{}
+    sticker = Repo.insert! %Sticker{receiver_id: user.id, sender_id: other_user.id}
+
+    conn = get conn, sticker_path(conn, :show, sticker)
+
+    assert json_response(conn, 200)["data"] == %{
+      "id" => to_string(sticker.id),
+      "type" => "sticker",
+      "attributes" => %{
+        "title" => sticker.title
+      },
+      "relationships" => %{
+        "receiver" => %{
+          "links" => %{
+            "related" => "http://localhost:4001/api/user/#{user.id}"
+          }
+        },
+        "sender" => %{
+          "links" => %{
+            "related" => "http://localhost:4001/api/user/#{other_user.id}"
+          }
+        }
+      }
+    }
+  end
+
+  test "does not show resource and instead throw error when id is nonexistent", %{conn: conn, user: _user} do
+    assert_error_sent 404, fn ->
+      get conn, sticker_path(conn, :show, -1)
+    end
+  end
+
+  test "creates and renders resource when data is valid, using id", %{conn: conn, user: user} do
+    other_user = Repo.insert! %Reverie.User{}
+    conn = post conn, sticker_path(conn, :create), data: %{type: "stickers", attributes: @valid_attrs, relationships: %{"data": %{"type": "users", "id": other_user.id}}}
+    assert json_response(conn, 201)["data"]["id"]
+    assert Repo.get_by(Sticker, @valid_attrs)
+  end
+
+  test "does not create resource and renders errors when data is invalid", %{conn: conn, user: user} do
+    other_user = Repo.insert! %Reverie.User{}
+
+    conn = post conn, sticker_path(conn, :create), data: %{type: "stickers", attributes: @invalid_attrs, relationships: %{"data": %{"type": "users", "id": other_user.id}}}
+
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "deletes chosen resource", %{conn: conn, user: user} do
+    other_user = Repo.insert! %Reverie.User{}
+    sticker = Repo.insert! %Sticker{receiver_id: user.id, sender_id: other_user.id}
+    conn = delete conn, sticker_path(conn, :delete, sticker)
+    assert response(conn, 204)
+    refute Repo.get(Sticker, sticker.id)
+  end
+end

--- a/test/models/sticker_test.exs
+++ b/test/models/sticker_test.exs
@@ -1,0 +1,18 @@
+defmodule Reverie.StickerTest do
+  use Reverie.ModelCase
+
+  alias Reverie.Sticker
+
+  @valid_attrs %{title: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Sticker.changeset(%Sticker{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Sticker.changeset(%Sticker{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/models/sticker_test.exs
+++ b/test/models/sticker_test.exs
@@ -7,8 +7,13 @@ defmodule Reverie.StickerTest do
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do
-    changeset = Sticker.changeset(%Sticker{}, @valid_attrs)
+    changeset = Sticker.changeset(%Sticker{receiver_id: 1, sender_id: 2}, @valid_attrs)
     assert changeset.valid?
+  end
+
+  test "changeset with same sender and receive" do
+    changeset = Sticker.changeset(%Sticker{receiver_id: 1, sender_id: 1}, @valid_attrs)
+    refute changeset.valid?
   end
 
   test "changeset with invalid attributes" do

--- a/web/controllers/sticker_controller.ex
+++ b/web/controllers/sticker_controller.ex
@@ -1,0 +1,136 @@
+defmodule Reverie.StickerController do
+  use Reverie.Web, :controller
+  import Ecto.Query
+  import Logger
+
+  alias Reverie.Sticker
+
+  # Enforce user authentication
+  plug Guardian.Plug.EnsureAuthenticated, handler: Reverie.AuthErrorHandler
+
+  # List of Stickers by owner (receiver), based on token
+  def index(conn, %{"user_id" => user_id}) do
+    current_user = Guardian.Plug.current_resource(conn)
+
+    case to_string(user_id) == to_string(current_user.id) do
+      true ->
+        stickers = Sticker
+        |> where(receiver_id: ^current_user.id)
+        |> Repo.all
+        render(conn, "index.json", data: stickers)
+
+      false ->
+        conn
+        |> put_status(404)
+        |> render(Reverie.ErrorView, "404.json")
+    end
+  end
+
+  # NOTE: Only include when admin roles are implemented (if even)
+  # def index(conn, _params) do
+    # stickers = Repo.all(Sticker)
+    # render(conn, "index.json", data: stickers)
+  # end
+
+  def create(conn, %{"data" => %{"type" => "stickers", "attributes" => sticker_params, "relationships" => relationships}}) do
+    # Get the current user from the token, add it to changeset
+    # Thus, the user doesn't provide an ID; it is inferred from the request
+    current_user = Guardian.Plug.current_resource(conn)
+
+    receiver = relationships
+    |> build_receiver_relationship
+
+    # Pass both sender and receiver IDs, use changeset for validation
+    changeset = Sticker.changeset(%Sticker{sender_id: current_user.id, receiver_id: receiver.id}, sticker_params)
+
+    case Repo.insert(changeset) do
+      {:ok, sticker} ->
+        conn
+        |> put_status(:created)
+        |> put_resp_header("location", sticker_path(conn, :show, sticker))
+        |> render("show.json", data: sticker)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Reverie.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  # NOTE: I believe these are ok here, since we are at the API boundary
+  #   however, I am not sure whether passing in the id straight into Sticker
+  #   is correct, or whether we should be using the changeset.
+  # NOTE: the relationship here is "email", but the spec says "id"...
+  defp build_receiver_relationship(%{"data" => %{"type" => users, "email" => user_email}}) do
+    # Get unique receiver
+    # TODO: add "not sender" constraint
+    receiving_user = Reverie.User
+    |> where(email: ^user_email)
+    |> Repo.one!
+
+    receiving_user
+  end
+
+  # Works with id, per the spec
+  defp build_receiver_relationship(%{"data" => %{"type" => users, "id" => id}}) do
+    receiving_user = Reverie.User
+    |> where(id: ^id)
+    |> Repo.one!
+
+    receiving_user
+  end
+
+  # Show a certain sticker if it belongs to the user
+  def show(conn, %{"id" => id}) do
+    current_user = Guardian.Plug.current_resource(conn)
+
+    sticker = Sticker
+    |> where(receiver_id: ^current_user.id, id: ^id)
+    |> Repo.one!
+
+    render(conn, "show.json", data: sticker)
+  end
+
+  def update(conn, %{"id" => id, "data" => %{"id" => _, "type" => "sticker", "attributes" => sticker_params}}) do
+    # NOTE: function not loaded in router; unsure whether someone
+    # should edit a sticker.
+    # Also, who would do it, the sender or receiver?
+    current_user = Guardian.Plug.current_resource(conn)
+
+    # Authorization backed by the database
+    # if the query doesn't return a result (i.e. owner is not the current)
+    # then a 404 is raised
+    sticker = Sticker
+    |> where(sender_id: ^current_user.id, id: ^id)
+    |> Repo.one!
+
+    changeset = Sticker.changeset(sticker, sticker_params)
+
+    case Repo.update(changeset) do
+      {:ok, sticker} ->
+        render(conn, "show.json", data: sticker)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Reverie.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    # NOTE: currently only the receiver can delete a sticker
+    # When we add authorization schemes, should admins do it too?
+    current_user = Guardian.Plug.current_resource(conn)
+
+    # Authorization backed by the database
+    # if the query doesn't return a result (i.e. receiver is not the current)
+    # then a 404 is raised
+    sticker = Sticker
+    |> where(receiver_id: ^current_user.id, id: ^id)
+    |> Repo.one!
+
+    # Here we use delete! (with a bang) because we expect
+    # it to always work (and if it does not, it will raise).
+    Repo.delete!(sticker)
+
+    send_resp(conn, :no_content, "")
+  end
+end

--- a/web/controllers/sticker_controller.ex
+++ b/web/controllers/sticker_controller.ex
@@ -78,6 +78,16 @@ defmodule Reverie.StickerController do
     receiving_user
   end
 
+  # Works with id, and redundant sender relationship
+  # TODO: make this the only form accepted?
+  defp build_receiver_relationship(%{"receiver" => %{"data" => %{"type" => users, "id" => id}}, "sender" => _}) do
+    receiving_user = Reverie.User
+    |> where(id: ^id)
+    |> Repo.one!
+
+    receiving_user
+  end
+
   # Show a certain sticker if it belongs to the user
   def show(conn, %{"id" => id}) do
     current_user = Guardian.Plug.current_resource(conn)

--- a/web/controllers/sticker_controller.ex
+++ b/web/controllers/sticker_controller.ex
@@ -62,7 +62,6 @@ defmodule Reverie.StickerController do
   # NOTE: the relationship here is "email", but the spec says "id"...
   defp build_receiver_relationship(%{"data" => %{"type" => users, "email" => user_email}}) do
     # Get unique receiver
-    # TODO: add "not sender" constraint
     receiving_user = Reverie.User
     |> where(email: ^user_email)
     |> Repo.one!

--- a/web/controllers/sticker_controller.ex
+++ b/web/controllers/sticker_controller.ex
@@ -56,30 +56,7 @@ defmodule Reverie.StickerController do
     end
   end
 
-  # NOTE: I believe these are ok here, since we are at the API boundary
-  #   however, I am not sure whether passing in the id straight into Sticker
-  #   is correct, or whether we should be using the changeset.
-  # NOTE: the relationship here is "email", but the spec says "id"...
-  defp build_receiver_relationship(%{"data" => %{"type" => users, "email" => user_email}}) do
-    # Get unique receiver
-    receiving_user = Reverie.User
-    |> where(email: ^user_email)
-    |> Repo.one!
-
-    receiving_user
-  end
-
-  # Works with id, per the spec
-  defp build_receiver_relationship(%{"data" => %{"type" => users, "id" => id}}) do
-    receiving_user = Reverie.User
-    |> where(id: ^id)
-    |> Repo.one!
-
-    receiving_user
-  end
-
   # Works with id, and redundant sender relationship
-  # TODO: make this the only form accepted?
   defp build_receiver_relationship(%{"receiver" => %{"data" => %{"type" => users, "id" => id}}, "sender" => _}) do
     receiving_user = Reverie.User
     |> where(id: ^id)

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -1,10 +1,31 @@
 defmodule Reverie.UserController do
     use Reverie.Web, :controller
+    use Inquisitor, with: Reverie.User, whitelist: ["email"]
 
     alias Reverie.User
 
     # Enforce user authentication
     plug Guardian.Plug.EnsureAuthenticated, handler: Reverie.AuthErrorHandler
+
+    # NOTE: this uses build_query_params from Inquisitor to contruct
+    # an Ecto where clause with key-value filters. The whitelist at
+    # the top of this module sets allowable params. While the docs
+    # state that the naked "params" is enough, our current setup
+    # returns query params under "filter". it might be desirable to
+    # set up a more elaborate pattern in the future.
+    def index(conn, %{"filter" => params}) do
+      users =
+        build_user_query(params)
+        |> Repo.all()
+      render(conn, "index.json", data: users)
+    end
+
+    def index(conn, [%{"filter" => params}|_tail_params]) do
+      users =
+        build_user_query(params)
+        |> Repo.all()
+      render(conn, "index.json", data: users)
+    end
 
     def index(conn, _params) do
       users = Repo.all(User)

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -6,12 +6,22 @@ defmodule Reverie.UserController do
     # Enforce user authentication
     plug Guardian.Plug.EnsureAuthenticated, handler: Reverie.AuthErrorHandler
 
+    def index(conn, _params) do
+      users = Repo.all(User)
+      render(conn, "index.json", data: users)
+    end
+
+    def show(conn, %{"id" => id}) do
+      user = Repo.get!(User, id)
+      render(conn, "show.json", data: user)
+    end
+
     def current(conn, _) do
         # Get user, whom Guardian has extracted from token in api_auth
         user = conn
         |> Guardian.Plug.current_resource
 
         conn
-        |> render(Reverie.UserView, "show.json", user: user)
+        |> render(Reverie.UserView, "show.json", data: user)
     end
 end

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -9,26 +9,11 @@ defmodule Reverie.UserController do
 
     # NOTE: this uses build_query_params from Inquisitor to contruct
     # an Ecto where clause with key-value filters. The whitelist at
-    # the top of this module sets allowable params. While the docs
-    # state that the naked "params" is enough, our current setup
-    # returns query params under "filter". it might be desirable to
-    # set up a more elaborate pattern in the future.
-    def index(conn, %{"filter" => params}) do
-      users =
-        build_user_query(params)
+    # the top of this module sets allowable params.
+    def index(conn, params) do
+      users = params
+        |> build_user_query()
         |> Repo.all()
-      render(conn, "index.json", data: users)
-    end
-
-    def index(conn, [%{"filter" => params}|_tail_params]) do
-      users =
-        build_user_query(params)
-        |> Repo.all()
-      render(conn, "index.json", data: users)
-    end
-
-    def index(conn, _params) do
-      users = Repo.all(User)
       render(conn, "index.json", data: users)
     end
 

--- a/web/models/sticker.ex
+++ b/web/models/sticker.ex
@@ -15,7 +15,20 @@ defmodule Reverie.Sticker do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:title])
-    |> validate_required([:title])
+    |> validate_required([:title, :receiver_id, :sender_id])
     |> validate_length(:title, min: 4)
+    |> validate_different_user
+  end
+
+  defp validate_different_user(changeset) do
+    receiver_id = get_field(changeset, :receiver_id)
+    sender_id = get_field(changeset, :sender_id)
+
+    case receiver_id == sender_id do
+      true ->
+        add_error(changeset, :receiver_id, "you cannot send stickers to yourself")
+      false ->
+        changeset
+    end
   end
 end

--- a/web/models/sticker.ex
+++ b/web/models/sticker.ex
@@ -26,7 +26,7 @@ defmodule Reverie.Sticker do
 
     case receiver_id == sender_id do
       true ->
-        add_error(changeset, :receiver_id, "you cannot send stickers to yourself")
+        add_error(changeset, :receiver_id, "cannot be the same as sender", [validation: :same_user])
       false ->
         changeset
     end

--- a/web/models/sticker.ex
+++ b/web/models/sticker.ex
@@ -1,0 +1,21 @@
+defmodule Reverie.Sticker do
+  use Reverie.Web, :model
+
+  schema "stickers" do
+    field :title, :string
+    belongs_to :sender, Reverie.Sender
+    belongs_to :receiver, Reverie.Receiver
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:title])
+    |> validate_required([:title])
+    |> validate_length(:title, min: 4)
+  end
+end

--- a/web/models/sticker.ex
+++ b/web/models/sticker.ex
@@ -14,7 +14,7 @@ defmodule Reverie.Sticker do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:title])
+    |> cast(params, [:title, :receiver_id, :sender_id])
     |> validate_required([:title, :receiver_id, :sender_id])
     |> validate_length(:title, min: 4)
     |> validate_different_user

--- a/web/models/sticker.ex
+++ b/web/models/sticker.ex
@@ -3,8 +3,8 @@ defmodule Reverie.Sticker do
 
   schema "stickers" do
     field :title, :string
-    belongs_to :sender, Reverie.Sender
-    belongs_to :receiver, Reverie.Receiver
+    belongs_to :sender, Reverie.User
+    belongs_to :receiver, Reverie.User
 
     timestamps()
   end

--- a/web/router.ex
+++ b/web/router.ex
@@ -37,6 +37,6 @@ defmodule Reverie.Router do
 
     # New and Edit are not used in APIs;
     # Update is excluded for now (see note in sticker_controller.ex)
-    resources "/stickers", StickerController, except: [:new, :edit, :update]
+    resources "/stickers", StickerController, except: [:new, :edit]
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -27,7 +27,16 @@ defmodule Reverie.Router do
 
   # Authenticated scope
   scope "/api", Reverie do
-      pipe_through :api_auth
-      get "/user/current", UserController, :current
+    pipe_through :api_auth
+
+    # Users
+    get "/user/current", UserController, :current, as: :current_user
+    resources "/user", UserController, only: [:show, :index] do
+      get "/stickers", StickerController, :index, as: :stickers
+    end
+
+    # New and Edit are not used in APIs;
+    # Update is excluded for now (see note in sticker_controller.ex)
+    resources "/stickers", StickerController, except: [:new, :edit, :update]
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -30,8 +30,8 @@ defmodule Reverie.Router do
     pipe_through :api_auth
 
     # Users
-    get "/user/current", UserController, :current, as: :current_user
-    resources "/user", UserController, only: [:show, :index] do
+    get "/users/current", UserController, :current, as: :current_user
+    resources "/users", UserController, only: [:show, :index] do
       get "/stickers", StickerController, :index, as: :stickers
     end
 

--- a/web/views/sticker_view.ex
+++ b/web/views/sticker_view.ex
@@ -1,0 +1,31 @@
+defmodule Reverie.StickerView do
+  use Reverie.Web, :view
+  use JaSerializer.PhoenixView
+
+  attributes [:title]
+  has_one :sender, link: :sender_link
+  has_one :receiver, link: :receiver_link
+
+  def sender_link(room, conn) do
+    user_url(conn, :show, room.sender_id)
+  end
+
+  def receiver_link(room, conn) do
+    user_url(conn, :show, room.receiver_id)
+  end
+
+  def render("index.json", %{data: stickers}) do
+    %{data: render_many(stickers, Reverie.StickerView, "sticker.json")}
+  end
+
+  def render("show.json", %{data: sticker}) do
+    %{data: render_one(sticker, Reverie.StickerView, "sticker.json")}
+  end
+
+  def render("sticker.json", %{data: sticker}) do
+    %{id: sticker.id,
+      title: sticker.title,
+      sender_id: sticker.sender_id,
+      receiver_id: sticker.receiver_id}
+  end
+end

--- a/web/views/sticker_view.ex
+++ b/web/views/sticker_view.ex
@@ -3,15 +3,24 @@ defmodule Reverie.StickerView do
   use JaSerializer.PhoenixView
 
   attributes [:title]
-  has_one :sender, link: :sender_link
-  has_one :receiver, link: :receiver_link
+  has_one :sender,
+    serializer: Reverie.UserView,
+    link: :sender_link,
+    include: false,
+    identifiers: :when_included
 
-  def sender_link(room, conn) do
-    user_url(conn, :show, room.sender_id)
+  has_one :receiver,
+    serializer: Reverie.UserView,
+    link: :receiver_link,
+    include: false,
+    identifiers: :when_included
+
+  def sender_link(sticker, conn) do
+    user_url(conn, :show, sticker.sender_id)
   end
 
-  def receiver_link(room, conn) do
-    user_url(conn, :show, room.receiver_id)
+  def receiver_link(sticker, conn) do
+    user_url(conn, :show, sticker.receiver_id)
   end
 
   def render("index.json", %{data: stickers}) do

--- a/web/views/user_view.ex
+++ b/web/views/user_view.ex
@@ -1,16 +1,24 @@
 defmodule Reverie.UserView do
     use Reverie.Web, :view
+    use JaSerializer.PhoenixView
 
-    def render("index.json", %{users: users}) do
+    attributes [:email]
+    has_many :stickers, link: :stickers_link
+
+    def stickers_link(user, conn) do
+      user_stickers_url(conn, :index, user.id)
+    end
+
+    def render("index.json", %{data: users}) do
         %{data: render_many(users, Reverie.UserView, "user.json")}
     end
 
-    def render("show.json", %{user: user}) do
+    def render("show.json", %{data: user}) do
         %{data: render_one(user, Reverie.UserView, "user.json")}
     end
 
     # Render single user in JSONAPI format
-    def render("user.json", %{user: user}) do
+    def render("user.json", %{data: user}) do
         %{
             "type": "user",
             "id": user.id,

--- a/worklog
+++ b/worklog
@@ -1,3 +1,11 @@
+Data loading improvements:
+  Implement GET /api/stickers?user_id=X
+
+  [DONE] Implemet GET /api/users?username=X
+    in contrast to ?filter
+
+  Implement ?include for stickers
+
 Further work: better stickers
   Sticker
   Title
@@ -10,4 +18,7 @@ Further work: better stickers
 Add send/receive method
   name: enum['a', 'b', 'c'] |> validate
 
-Handle sent stickers
+Add include parameter from JSON API spec;
+  this allows sideloading user first/last name for stickers
+
+Handle/present sent stickers for a user

--- a/worklog
+++ b/worklog
@@ -1,11 +1,3 @@
-Data loading improvements:
-  Implement GET /api/stickers?user_id=X
-
-  [DONE] Implemet GET /api/users?username=X
-    in contrast to ?filter
-
-  Implement ?include for stickers
-
 Further work: better stickers
   Sticker
   Title
@@ -18,8 +10,5 @@ Further work: better stickers
 
 Add send/receive method
   name: enum['a', 'b', 'c'] |> validate
-
-Add include parameter from JSON API spec;
-  this allows sideloading user first/last name for stickers
 
 Handle/present sent stickers for a user

--- a/worklog
+++ b/worklog
@@ -1,16 +1,17 @@
-Generate code;
-  Sticker
-  name: string
-  sender_id: references(users)
-  receiver_id: references(users)
+TODO:
+  Clean up TODOs in code
+    Remove redundant build_relationship(s) and update tests
 
-  TODO optional:
+  Add filter parameters for email
+
+Further work
+  Sticker
+  Title
+    enum of category
+    validation
+  Optional params:
     message
       validation: 150 chars
 
 Add send/receive method
-  Send:
-  ensure_authenticated
-  TODO name: enum['a', 'b', 'c'] |> validate
-  sender_id: Guardian.load_resource
-  receiver_id: username |> user_by_id
+  name: enum['a', 'b', 'c'] |> validate

--- a/worklog
+++ b/worklog
@@ -10,7 +10,8 @@ Further work: better stickers
   Sticker
   Title
     enum of category
-    validation
+      validation
+    s3 link
   Optional params:
     message
       validation: 150 chars

--- a/worklog
+++ b/worklog
@@ -1,10 +1,4 @@
-TODO:
-  Clean up TODOs in code
-    Remove redundant build_relationship(s) and update tests
-
-  Add filter parameters for email
-
-Further work
+Further work: better stickers
   Sticker
   Title
     enum of category

--- a/worklog
+++ b/worklog
@@ -1,0 +1,16 @@
+Generate code;
+  Sticker
+  name: string
+  sender_id: references(users)
+  receiver_id: references(users)
+
+  TODO optional:
+    message
+      validation: 150 chars
+
+Add send/receive method
+  Send:
+  ensure_authenticated
+  TODO name: enum['a', 'b', 'c'] |> validate
+  sender_id: Guardian.load_resource
+  receiver_id: username |> user_by_id

--- a/worklog
+++ b/worklog
@@ -15,3 +15,5 @@ Further work
 
 Add send/receive method
   name: enum['a', 'b', 'c'] |> validate
+
+Handle sent stickers


### PR DESCRIPTION
This PR adds stickers to the back-end. Stickers are (currently) messages with a sender and a receiver. Any user can send stickers to another one, but only the current can view their own collection.  

This API follows the jsonapi.org spec, but keeps some things lightweight, such as omitting some "unsupported" responses. Since we expect users to have many stickers at the session, the API provides the option to "sideload" the users in sticker relations. Thus, when GETting the stickers for a user, the sender's details are included in a separate array, using type+id as the key. This is where the pairing with Ember shines, allowing all this (de)serialization to be almost automatic. 

The one caveat is that we do sideloading by default here, for all GET /api/user/:id/stickers or /api/stickers?user_id=:id, due to conflicting thoughts on how to use *params* in the controllers. The front-end still includes the redundant ?include=sender, so the future change won't affect it.

In the future, more features will be added to stickers, but the API will be nearly unchanged. 